### PR TITLE
Håndter syfoservice overføring

### DIFF
--- a/js/sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknader.js
+++ b/js/sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknader.js
@@ -1,5 +1,6 @@
 import { parseSykepengesoknad, tidligsteFom, senesteTom, sykepengesoknadstatuser } from '@navikt/digisyfo-npm';
 import * as actiontyper from '../../../data/actiontyper';
+import { selectSykepengesoknaderData } from './sykepengesoknaderSelectors';
 
 const { KORRIGERT, AVBRUTT, NY, UTKAST_TIL_KORRIGERING, SLETTET_UTKAST } = sykepengesoknadstatuser;
 
@@ -58,7 +59,7 @@ export const settErOppdelt = (soknad) => {
 };
 
 export const finnSoknad = (state, id) => {
-    return state.sykepengesoknader.data.filter((s) => {
+    return selectSykepengesoknaderData(state).filter((s) => {
         return `${s.id}` === id;
     })[0] || {};
 };

--- a/js/sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors.js
+++ b/js/sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors.js
@@ -1,11 +1,13 @@
 /* eslint arrow-body-style: ["error", "as-needed"] */
 import { sykepengesoknadstatuser } from '@navikt/digisyfo-npm';
+import { selectSoknaderData } from '../../../sykepengesoknad/data/soknader/soknaderSelectors';
 
 const { NY, FREMTIDIG } = sykepengesoknadstatuser;
 
 const selectSlice = state => state.sykepengesoknader;
 
-export const selectSykepengesoknaderData = state => selectSlice(state).data;
+export const selectSykepengesoknaderData = state => selectSlice(state).data
+    .filter(soknad => !selectSoknaderData(state).map(s => s.id).includes(soknad.id));
 
 const selectHenter = state => selectSlice(state).henter;
 const selectHentet = state => selectSlice(state).hentet;

--- a/js/sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors.js
+++ b/js/sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors.js
@@ -1,15 +1,21 @@
+/* eslint arrow-body-style: ["error", "as-needed"] */
 import { sykepengesoknadstatuser } from '@navikt/digisyfo-npm';
 
-export const erForsteSykepengesoknad = (state) => {
-    return state.sykepengesoknader.data
-        && state.sykepengesoknader.data.filter((s) => {
-            return s.status === sykepengesoknadstatuser.NY
-                || s.status === sykepengesoknadstatuser.FREMTIDIG;
-        }).length === state.sykepengesoknader.data.length;
-};
+const { NY, FREMTIDIG } = sykepengesoknadstatuser;
 
-export const skalHenteSykepengesoknader = (state) => {
-    return !state.sykepengesoknader.henter
-        && !state.sykepengesoknader.hentet
-        && !state.sykepengesoknader.hentingFeilet;
-};
+const selectSlice = state => state.sykepengesoknader;
+
+export const selectSykepengesoknaderData = state => selectSlice(state).data;
+
+const selectHenter = state => selectSlice(state).henter;
+const selectHentet = state => selectSlice(state).hentet;
+const selectHentingFeilet = state => selectSlice(state).hentingFeilet;
+
+export const erForsteSykepengesoknad = state => selectSykepengesoknaderData(state)
+    .map(soknad => soknad.status)
+    .filter(status => [NY, FREMTIDIG].includes(status))
+    .length === selectSykepengesoknaderData(state).length;
+
+export const skalHenteSykepengesoknader = state => !selectHenter(state)
+    && !selectHentet(state)
+    && !selectHentingFeilet(state);

--- a/js/sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors.test.js
+++ b/js/sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors.test.js
@@ -1,0 +1,42 @@
+/* eslint arrow-body-style: ["error", "as-needed"] */
+import { expect } from 'chai';
+import { selectSykepengesoknaderData } from './sykepengesoknaderSelectors';
+
+describe('Sykepengesoknader selectors', () => {
+    it('skal kunne hente data fra sykepengesoknader state', () => {
+        const state = {
+            sykepengesoknader: {
+                henter: false,
+                hentet: true,
+                hentingFeilet: false,
+                data: [{ id: 1 }],
+            },
+            soknader: {
+                henter: false,
+                hentet: true,
+                hentingFeilet: false,
+                data: [],
+            },
+        };
+        expect(selectSykepengesoknaderData(state)).to.deep.equal([{ id: 1 }]);
+    });
+
+    it('skal kun hente soknader med id som ikke finnes blandt nye søknader', () => {
+        const state = {
+            sykepengesoknader: {
+                henter: false,
+                hentet: true,
+                hentingFeilet: false,
+                data: [{ id: 1 }, { id: 2 }],
+            },
+            soknader: {
+                henter: false,
+                hentet: true,
+                hentingFeilet: false,
+                data: [{ id: 2 }],
+            },
+        };
+
+        expect(selectSykepengesoknaderData(state)).to.deep.equal([{ id: 1 }]);
+    });
+});

--- a/js/sykepengesoknad-gammel-plattform/for-du-begynner/FoerDuBegynnerContainer.js
+++ b/js/sykepengesoknad-gammel-plattform/for-du-begynner/FoerDuBegynnerContainer.js
@@ -13,7 +13,9 @@ import { sykepengesoknad as sykepengesoknadPt } from '../../propTypes/index';
 import { hentBerikelse } from '../data/sykepengesoknader/sykepengesoknader_actions';
 import SoknadAvbrutt from '../soknad/soknad-avbrutt/SoknadAvbrutt';
 import { filtrerOgSorterNyeSoknader } from '../sykepengesoknader/Soknader';
-import { erForsteSykepengesoknad } from '../data/sykepengesoknader/sykepengesoknaderSelectors';
+import {
+    erForsteSykepengesoknad, selectSykepengesoknaderData,
+} from '../data/sykepengesoknader/sykepengesoknaderSelectors';
 import { utfyllingStartet as utfyllingStartetAction } from '../../data/metrikker/metrikker_actions';
 
 const { NY, SENDT, UTGAATT, TIL_SENDING, UTKAST_TIL_KORRIGERING, KORRIGERT, AVBRUTT, SLETTET_UTKAST } = sykepengesoknadstatuser;
@@ -103,11 +105,11 @@ Container.propTypes = {
 export const mapStateToProps = (state, ownProps) => {
     const henter = state.vedlikehold.henter || state.sykepengesoknader.henterBerikelse;
     const sykepengesoknadId = ownProps.params.sykepengesoknadId;
-    const skalHenteBerikelse = state.sykepengesoknader.data.some((s) => {
+    const skalHenteBerikelse = selectSykepengesoknaderData(state).some((s) => {
         return s.id === sykepengesoknadId;
     });
 
-    const soknader = filtrerOgSorterNyeSoknader(state.sykepengesoknader.data);
+    const soknader = filtrerOgSorterNyeSoknader(selectSykepengesoknaderData(state));
     const eldsteSoknadId = soknader[0] ? soknader[0].id : '';
     const detFinnesEldreSoknader = eldsteSoknadId !== sykepengesoknadId;
 

--- a/js/sykepengesoknad-gammel-plattform/relaterte-soknader/RelaterteSoknaderContainer.js
+++ b/js/sykepengesoknad-gammel-plattform/relaterte-soknader/RelaterteSoknaderContainer.js
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 import RelaterteSoknader from './RelaterteSoknader';
+import { selectSykepengesoknaderData } from '../data/sykepengesoknader/sykepengesoknaderSelectors';
 
 export const mapStateToProps = (state, ownProps) => {
     const relaterteSoknader = [];
     const sykepengesoknadId = ownProps.sykepengesoknadId;
-    const sykepengesoknader = state.sykepengesoknader.data;
+    const sykepengesoknader = selectSykepengesoknaderData(state);
     let sykepengesoknad = sykepengesoknader.filter((s) => {
         return s.id === sykepengesoknadId;
     })[0];

--- a/js/sykepengesoknad-gammel-plattform/sider/SoknaderSide.js
+++ b/js/sykepengesoknad-gammel-plattform/sider/SoknaderSide.js
@@ -14,7 +14,7 @@ import {
     skalHenteSykepengesoknader,
     selectSykepengesoknaderData,
 } from '../data/sykepengesoknader/sykepengesoknaderSelectors';
-import { skalHenteSoknader } from '../../sykepengesoknad/data/soknader/soknaderSelectors';
+import { selectSoknaderData, skalHenteSoknader } from '../../sykepengesoknad/data/soknader/soknaderSelectors';
 import { selectSkalHenteDineSykmeldinger } from '../../data/dine-sykmeldinger/dineSykmeldingerSelectors';
 import { hentDineSykmeldinger } from '../../data/dine-sykmeldinger/dineSykmeldingerActions';
 import { ARBEIDSTAKERE } from '../../sykepengesoknad/enums/soknadtyper';
@@ -79,7 +79,7 @@ export function mapStateToProps(state) {
     const sykepengesoknader = selectSykepengesoknaderData(state);
     const dineSykmeldinger = state.dineSykmeldinger.data;
     const soknader = toggleNyArbeidstakerSoknad(state)
-        ? state.soknader.data.map((soknad) => {
+        ? selectSoknaderData(state).map((soknad) => {
             const sykmelding = dineSykmeldinger.find((sykmld) => {
                 return sykmld.id === soknad.sykmeldingId;
             });
@@ -90,7 +90,7 @@ export function mapStateToProps(state) {
                 }
                 : soknad;
         })
-        : state.soknader.data.filter((s) => {
+        : selectSoknaderData(state).filter((s) => {
             return s.soknadstype !== ARBEIDSTAKERE;
         });
 

--- a/js/sykepengesoknad-gammel-plattform/sider/SoknaderSide.js
+++ b/js/sykepengesoknad-gammel-plattform/sider/SoknaderSide.js
@@ -10,7 +10,10 @@ import Feilmelding from '../../components/Feilmelding';
 import { sykepengesoknad as sykepengesoknadPt, brodsmule as brodsmulePt, soknadPt } from '../../propTypes/index';
 import { hentSykepengesoknader } from '../data/sykepengesoknader/sykepengesoknader_actions';
 import { hentSoknader } from '../../sykepengesoknad/data/soknader/soknaderActions';
-import { skalHenteSykepengesoknader } from '../data/sykepengesoknader/sykepengesoknaderSelectors';
+import {
+    skalHenteSykepengesoknader,
+    selectSykepengesoknaderData,
+} from '../data/sykepengesoknader/sykepengesoknaderSelectors';
 import { skalHenteSoknader } from '../../sykepengesoknad/data/soknader/soknaderSelectors';
 import { selectSkalHenteDineSykmeldinger } from '../../data/dine-sykmeldinger/dineSykmeldingerSelectors';
 import { hentDineSykmeldinger } from '../../data/dine-sykmeldinger/dineSykmeldingerActions';
@@ -73,7 +76,7 @@ export function mapDispatchToProps(dispatch) {
 }
 
 export function mapStateToProps(state) {
-    const sykepengesoknader = state.sykepengesoknader.data;
+    const sykepengesoknader = selectSykepengesoknaderData(state);
     const dineSykmeldinger = state.dineSykmeldinger.data;
     const soknader = toggleNyArbeidstakerSoknad(state)
         ? state.soknader.data.map((soknad) => {

--- a/js/sykepengesoknad-gammel-plattform/soknad/GenerellArbeidstakersoknadContainer.js
+++ b/js/sykepengesoknad-gammel-plattform/soknad/GenerellArbeidstakersoknadContainer.js
@@ -6,6 +6,7 @@ import Feilmelding from '../../components/Feilmelding';
 import { sykepengesoknad as sykepengesoknadPt } from '../../propTypes/index';
 import * as soknadActions from '../data/sykepengesoknader/sykepengesoknader_actions';
 import { getSoknadSkjemanavn } from '../../enums/skjemanavn';
+import { selectSykepengesoknaderData } from '../data/sykepengesoknader/sykepengesoknaderSelectors';
 
 const GenerellArbeidstakersoknadContainer = (props) => {
     const { Component, sykepengesoknad, hentingFeilet } = props;
@@ -43,7 +44,7 @@ export function mapDispatchToProps(dispatch) {
 }
 
 export const mapStateToProps = (state, ownProps) => {
-    const sykepengesoknad = state.sykepengesoknader.data.filter((soknad) => {
+    const sykepengesoknad = selectSykepengesoknaderData(state).filter((soknad) => {
         return soknad.id === ownProps.params.sykepengesoknadId;
     })[0];
     const skjemanavn = getSoknadSkjemanavn(ownProps.params.sykepengesoknadId);

--- a/js/sykepengesoknad-gammel-plattform/soknad/soknad-sendt/KorrigertAvContainer.js
+++ b/js/sykepengesoknad-gammel-plattform/soknad/soknad-sendt/KorrigertAvContainer.js
@@ -5,6 +5,7 @@ import { getLedetekst, tilLesbarDatoMedArstall } from '@navikt/digisyfo-npm';
 import Alertstripe from 'nav-frontend-alertstriper';
 import { sykepengesoknad as sykepengesoknadPt } from '../../../propTypes/index';
 import { getTidligsteSendtDato } from '../../utils/sorterSoknader';
+import { selectSykepengesoknaderData } from '../../data/sykepengesoknader/sykepengesoknaderSelectors';
 
 export const KorrigertAv = ({ korrigertAvSoknad }) => {
     return (<Alertstripe className="blokk" type="info">
@@ -26,7 +27,7 @@ KorrigertAv.propTypes = {
 export const mapStateToProps = (state, ownProps) => {
     const id = ownProps.sykepengesoknad.id;
     const sykepengesoknader = [
-        ...state.sykepengesoknader.data,
+        ...selectSykepengesoknaderData(state),
         ...state.soknader.data,
     ];
     let korrigertAvSoknad = { id };

--- a/js/sykepengesoknad-gammel-plattform/soknad/soknad-sendt/KorrigertAvContainer.js
+++ b/js/sykepengesoknad-gammel-plattform/soknad/soknad-sendt/KorrigertAvContainer.js
@@ -6,6 +6,7 @@ import Alertstripe from 'nav-frontend-alertstriper';
 import { sykepengesoknad as sykepengesoknadPt } from '../../../propTypes/index';
 import { getTidligsteSendtDato } from '../../utils/sorterSoknader';
 import { selectSykepengesoknaderData } from '../../data/sykepengesoknader/sykepengesoknaderSelectors';
+import { selectSoknaderData } from '../../../sykepengesoknad/data/soknader/soknaderSelectors';
 
 export const KorrigertAv = ({ korrigertAvSoknad }) => {
     return (<Alertstripe className="blokk" type="info">
@@ -28,7 +29,7 @@ export const mapStateToProps = (state, ownProps) => {
     const id = ownProps.sykepengesoknad.id;
     const sykepengesoknader = [
         ...selectSykepengesoknaderData(state),
-        ...state.soknader.data,
+        ...selectSoknaderData(state),
     ];
     let korrigertAvSoknad = { id };
 

--- a/js/sykepengesoknad-gammel-plattform/utils/reduxFormSetup.js
+++ b/js/sykepengesoknad-gammel-plattform/utils/reduxFormSetup.js
@@ -8,6 +8,7 @@ import { mapAktiviteter } from './sykepengesoknadUtils';
 import mapBackendsoknadToSkjemasoknad from '../mappers/mapBackendsoknadToSkjemasoknad';
 import { getSoknadSkjemanavn } from '../../enums/skjemanavn';
 import { getTidligsteSendtDato } from './sorterSoknader';
+import { selectSykepengesoknaderData } from '../data/sykepengesoknader/sykepengesoknaderSelectors';
 
 const sendTilFoerDuBegynner = (sykepengesoknad) => {
     history.replace(`${process.env.REACT_APP_CONTEXT_ROOT}/soknader/${sykepengesoknad.id}`);
@@ -113,7 +114,7 @@ export const mapToInitialValues = (soknad, soknader = []) => {
 export const getInitialValuesSykepengesoknad = (sykepengesoknad, state) => {
     return sykepengesoknad.status === sykepengesoknadstatuser.UTKAST_TIL_KORRIGERING
         ? mapBackendsoknadToSkjemasoknad(sykepengesoknad)
-        : mapToInitialValues(sykepengesoknad, state.sykepengesoknader.data);
+        : mapToInitialValues(sykepengesoknad, selectSykepengesoknaderData(state));
 };
 
 export const mapStateToProps = (state, ownProps) => {

--- a/js/sykepengesoknad/data/soknader/soknaderSelectors.js
+++ b/js/sykepengesoknad/data/soknader/soknaderSelectors.js
@@ -3,9 +3,9 @@ import { ARBEIDSTAKERE, SELVSTENDIGE_OG_FRILANSERE } from '../../enums/soknadtyp
 import { SENDT } from '../../enums/soknadstatuser';
 import { selectSykepengesoknaderData } from '../../../sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors';
 
-const selectSlice = state => state.soknader;
+const selectSlice = state => state.soknader || {};
 
-export const selectSoknaderData = state => selectSlice(state).data;
+export const selectSoknaderData = state => selectSlice(state).data || [];
 
 export const erForsteSoknad = (state) => {
     const sendteSoknader = selectSoknaderData(state)

--- a/js/sykepengesoknad/data/soknader/soknaderSelectors.js
+++ b/js/sykepengesoknad/data/soknader/soknaderSelectors.js
@@ -1,12 +1,13 @@
 import { SELVSTENDIGE_OG_FRILANSERE, ARBEIDSTAKERE } from '../../enums/soknadtyper';
 import { SENDT } from '../../enums/soknadstatuser';
+import { selectSykepengesoknaderData } from '../../../sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors';
 
 export const erForsteSoknad = (state) => {
     const sendteSoknader = state.soknader.data.filter((soknad) => {
         return (soknad.soknadstype === ARBEIDSTAKERE || soknad.soknadstype === SELVSTENDIGE_OG_FRILANSERE)
             && soknad.status === SENDT;
     });
-    const sendteSykepengesoknader = state.sykepengesoknader.data.filter((soknad) => {
+    const sendteSykepengesoknader = selectSykepengesoknaderData(state).filter((soknad) => {
         return soknad.status === SENDT;
     });
     return sendteSoknader.length === 0 && sendteSykepengesoknader.length === 0;

--- a/js/sykepengesoknad/data/soknader/soknaderSelectors.js
+++ b/js/sykepengesoknad/data/soknader/soknaderSelectors.js
@@ -1,36 +1,27 @@
-import { SELVSTENDIGE_OG_FRILANSERE, ARBEIDSTAKERE } from '../../enums/soknadtyper';
+/* eslint arrow-body-style: ["error", "as-needed"] */
+import { ARBEIDSTAKERE, SELVSTENDIGE_OG_FRILANSERE } from '../../enums/soknadtyper';
 import { SENDT } from '../../enums/soknadstatuser';
 import { selectSykepengesoknaderData } from '../../../sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors';
 
+const selectSlice = state => state.soknader;
+
+export const selectSoknaderData = state => selectSlice(state).data;
+
 export const erForsteSoknad = (state) => {
-    const sendteSoknader = state.soknader.data.filter((soknad) => {
-        return (soknad.soknadstype === ARBEIDSTAKERE || soknad.soknadstype === SELVSTENDIGE_OG_FRILANSERE)
-            && soknad.status === SENDT;
-    });
-    const sendteSykepengesoknader = selectSykepengesoknaderData(state).filter((soknad) => {
-        return soknad.status === SENDT;
-    });
+    const sendteSoknader = selectSoknaderData(state)
+        .filter(soknad => [ARBEIDSTAKERE, SELVSTENDIGE_OG_FRILANSERE].includes(soknad.soknadstype)
+            && soknad.status === SENDT);
+    const sendteSykepengesoknader = selectSykepengesoknaderData(state).filter(soknad => soknad.status === SENDT);
     return sendteSoknader.length === 0 && sendteSykepengesoknader.length === 0;
 };
 
-export const skalHenteSoknader = (state) => {
-    return !state.soknader.hentet
-        && !state.soknader.henter
-        && !state.soknader.hentingFeilet;
-};
+export const skalHenteSoknader = state => !selectSlice(state).hentet
+    && !selectSlice(state).henter
+    && !selectSlice(state).hentingFeilet;
 
-export const skalHenteSoknaderHvisIkkeHenter = (state) => {
-    return !state.soknader.henter;
-};
+export const skalHenteSoknaderHvisIkkeHenter = state => !selectSlice(state).henter;
 
-export const sykmeldingHarBehandletSoknad = (state, sykmeldingId) => {
-    return state.soknader.data.filter((soknad) => {
-        return soknad.sykmeldingId === sykmeldingId && soknad.status === SENDT;
-    }).length > 0;
-};
+export const sykmeldingHarBehandletSoknad = (state, sykmeldingId) => selectSoknaderData(state)
+    .filter(soknad => soknad.sykmeldingId === sykmeldingId && soknad.status === SENDT).length > 0;
 
-export const hentSoknad = (state, soknad) => {
-    return state.soknader.data.find((s) => {
-        return s.id === soknad.id;
-    });
-};
+export const hentSoknad = (state, soknad) => selectSoknaderData(state).find(s => s.id === soknad.id);

--- a/js/sykepengesoknad/felleskomponenter/relaterte-soknader/RelaterteSoknaderContainer.js
+++ b/js/sykepengesoknad/felleskomponenter/relaterte-soknader/RelaterteSoknaderContainer.js
@@ -1,11 +1,12 @@
 import { connect } from 'react-redux';
 import { soknadPt as sykepengesoknadPt } from '../../../propTypes/index';
 import { RelaterteSoknader } from './RelaterteSoknader';
+import { selectSoknaderData } from '../../data/soknader/soknaderSelectors';
 
 export const mapStateToProps = (state, ownProps) => {
     const relaterteSoknader = [];
     const sykepengesoknadId = ownProps.soknad.id;
-    const sykepengesoknader = state.soknader.data;
+    const sykepengesoknader = selectSoknaderData(state);
 
     let sykepengesoknad = sykepengesoknader.filter((s) => {
         return s.id === sykepengesoknadId;

--- a/js/sykepengesoknad/sider/SoknadSide.js
+++ b/js/sykepengesoknad/sider/SoknadSide.js
@@ -20,6 +20,7 @@ import { NY, UTKAST_TIL_KORRIGERING } from '../enums/soknadstatuser';
 import SykepengesoknadBanner from '../../components/soknad-felles/SykepengersoknadBanner';
 import { soknadPt } from '../prop-types/soknadProptype';
 import { brodsmule } from '../../propTypes';
+import { selectSykepengesoknaderData } from '../../sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors';
 
 const soknadSkalUtfylles = (soknad) => {
     return soknad && (soknad.status === NY || soknad.status === UTKAST_TIL_KORRIGERING);
@@ -135,7 +136,7 @@ export const mapStateToProps = (state, ownProps) => {
         return s.id === soknadId;
     };
     const soknad = state.soknader.data.find(finnSoknad);
-    const sykepengesoknad = state.sykepengesoknader.data.find(finnSoknad);
+    const sykepengesoknad = selectSykepengesoknaderData(state).find(finnSoknad);
     const erSelvstendigNaeringsdrivendeSoknad = soknad !== undefined && soknad.soknadstype === SELVSTENDIGE_OG_FRILANSERE;
     const erSoknadOmUtenlandsopphold = soknad !== undefined && soknad.soknadstype === OPPHOLD_UTLAND;
     const erNyArbeidstakersoknad = soknad !== undefined && soknad.soknadstype === ARBEIDSTAKERE;

--- a/js/sykepengesoknad/sider/SoknadSide.js
+++ b/js/sykepengesoknad/sider/SoknadSide.js
@@ -21,6 +21,7 @@ import SykepengesoknadBanner from '../../components/soknad-felles/Sykepengersokn
 import { soknadPt } from '../prop-types/soknadProptype';
 import { brodsmule } from '../../propTypes';
 import { selectSykepengesoknaderData } from '../../sykepengesoknad-gammel-plattform/data/sykepengesoknader/sykepengesoknaderSelectors';
+import { selectSoknaderData } from '../data/soknader/soknaderSelectors';
 
 const soknadSkalUtfylles = (soknad) => {
     return soknad && (soknad.status === NY || soknad.status === UTKAST_TIL_KORRIGERING);
@@ -135,7 +136,7 @@ export const mapStateToProps = (state, ownProps) => {
     const finnSoknad = (s) => {
         return s.id === soknadId;
     };
-    const soknad = state.soknader.data.find(finnSoknad);
+    const soknad = selectSoknaderData(state).find(finnSoknad);
     const sykepengesoknad = selectSykepengesoknaderData(state).find(finnSoknad);
     const erSelvstendigNaeringsdrivendeSoknad = soknad !== undefined && soknad.soknadstype === SELVSTENDIGE_OG_FRILANSERE;
     const erSoknadOmUtenlandsopphold = soknad !== undefined && soknad.soknadstype === OPPHOLD_UTLAND;

--- a/js/sykepengesoknad/soknad-utland/skjema/SoknadUtlandSkjemaContainer.js
+++ b/js/sykepengesoknad/soknad-utland/skjema/SoknadUtlandSkjemaContainer.js
@@ -13,6 +13,7 @@ import { JA } from '../../enums/svarEnums';
 import OppsummeringUtland from '../oppsummering/OppsummeringUtland';
 import KvitteringUtland from '../KvitteringUtland';
 import { FERIE } from '../../enums/tagtyper';
+import { selectSoknaderData } from '../../data/soknader/soknaderSelectors';
 
 
 export const UtlandSkjemaContainer = (props) => {
@@ -56,7 +57,7 @@ UtlandSkjemaContainer.propTypes = {
 };
 
 export const finnSoknad = (state, ownProps) => {
-    return state.soknader.data.find((s) => {
+    return selectSoknaderData(state).find((s) => {
         return (s.id === ownProps.params.sykepengesoknadId) && (s.status === NY || s.status === TIL_SENDING || s.status === SENDT);
     });
 };

--- a/js/sykepengesoknad/utils/soknadSetup.js
+++ b/js/sykepengesoknad/utils/soknadSetup.js
@@ -6,9 +6,10 @@ import { sendSoknad, lagreSoknad, oppdaterSoknader } from '../data/soknader/sokn
 import { getSoknadSkjemanavn } from '../../enums/skjemanavn';
 import { utfyllingStartet } from '../../data/metrikker/metrikker_actions';
 import fraBackendsoknadTilInitiellSoknad from './fraBackendsoknadTilInitiellSoknad';
+import { selectSoknaderData } from '../data/soknader/soknaderSelectors';
 
 export const finnSoknad = (state, ownProps) => {
-    const soknader = state.soknader.data.filter((s) => {
+    const soknader = selectSoknaderData(state).filter((s) => {
         return s.id === ownProps.params.sykepengesoknadId;
     });
     return soknader.length === 1 ? soknader[0] : undefined;


### PR DESCRIPTION
Når soknader blir overført til syfosoknad fra syfoservice vil fremdeles den gamle soknaden ligge i syfoservice en stund før vi er klare for å fjerne søknaden helt fra syfoservice. Dette vil føre til at vi får søknader med samme id i responsen fra syfoservice og syfosoknad. For å takle dette har jeg implementert selectorer for data for ny og gammel søknad. Selectoren for gammel søknad vil filtrere ut alle søknader som også finnes i ny søknad. Jeg er litt usikker på hvordan det kommer til å fungere med tanke på rekkefølgen ting hentes. Hvis ikke denne enkle naive løsningen virker kan det hende man må sjekke om nye søknader er hentet ok før man lar noen hente gamle søknader.